### PR TITLE
Avoid panic when error parse level

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -34,10 +34,13 @@ func New() *Logger {
 
 		lvl, err := zerolog.ParseLevel(strings.ToLower(env.LogLevel))
 		if err != nil {
-			panic(err)
+			fmt.Printf("[ LGGR ] Error parse level, got: %s \n", err)
+
+			lvl = zerolog.TraceLevel
+			fmt.Println("[ LGGR ] Switch level to TRACE")
 		}
 		logger = logger.Level(lvl)
-		fmt.Printf("[ LGGR ] Set logger level to %s \n", env.LogLevel)
+		fmt.Printf("[ LGGR ] Set logger level to %s \n", logger.GetLevel())
 
 		instance = &Logger{&logger}
 	})

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestLogger(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		os.Setenv("LOG_LEVEL", "trace")
+		os.Setenv("LOG_LEVEL", "unknown-level")
 		loggerTest := New()
 		if instance == nil {
 			t.Errorf("expecting instance not nil, got %v", loggerTest)


### PR DESCRIPTION
**Issues Number** : #113   

**Pull request type** :  🐞 Bug Fix

**Descriptions** :  
Remove panic when error parse level occurs and switch the level to TRACE

**Tests that have been done in this PR** :  

- [x] `make test` : pass  
- [x] `make lint` : pass  
- [x] `make build` : success  