### PR TITLE
VSCode:  change max string char go debug

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,14 @@
     "go.coverOnSingleTest": true,
     "go.lintTool": "golint",
     "go.toolsManagement.autoUpdate": true,
+    "go.delveConfig": {
+        "useApiV1": false,
+        "dlvLoadConfig": {
+            "followPointers": true,
+            "maxVariableRecurse": 3,
+            "maxStringLen": 400,
+            "maxArrayValues": 400,
+            "maxStructFields": -1
+        }
+    }
 }


### PR DESCRIPTION
**Issues Number** : -  

**Pull request type** :  🐞 Bug Fix

**Descriptions** :  
change ax string go debug from 64 to 400 character 

**Tests that have been done in this PR** :  

- [x] `make test` : pass  
- [x] `make lint` : pass  
- [x] `make build` : success  